### PR TITLE
ci: use reusable automerge workflow from cfg

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,29 +1,10 @@
 name: Auto Approve and Merge PRs
 
 on:
-  pull_request:
-
-permissions:
-  contents: write
-  pull-requests: write
-
-env:
-  PR_URL: ${{github.event.pull_request.html_url}}
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 jobs:
-  auto-approve-and-merge:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
-    steps:
-      - name: Wait for PR checks to complete
-        run: gh pr checks --required --fail-fast --watch "$PR_URL"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Enable auto-approve
-        run: gh pr review --approve "$PR_URL"
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Enable auto-merge
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  auto-approve-merge-dependabot:
+    uses: Neovici/cfg/.github/workflows/automerge.yml@master
+    secrets: inherit


### PR DESCRIPTION
Replace local automerge workflow with reusable workflow from Neovici/cfg to use consistent squash merge method across all repos.

Fixes FE-943